### PR TITLE
Fixing url to wiki page on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ git clone https://github.com/OCSInventory-NG/OCSInventory-ocsreports.git ocsrepo
 
 For more informations, please follow the OCS Inventory documentation :
 
-http://wiki.ocsinventory-ng.org/02.Basic-documentation/Setting-up-a-OCS-Inventory-Server/
+http://wiki.ocsinventory-ng.org/03.Basic-documentation/Setting-up-a-OCS-Inventory-Server/
 
 ## Contributing
 


### PR DESCRIPTION
## Important notes 
Please, don't mistake OCSInventory-server with OCSInventory-ocsreports :
* OCSInventory-server : Communication server that manage the inventory
* OCSInventory-ocsreports : Web interface of OCS Inventory

## General informations :
Operating system :

## Server informations :
Perl version :
Mysql / Mariadb / Percona version :  

## Status :
**READY/IN DEVELOPMENT/HOLD**

## Description :
A few sentences describing the overall goals of the pull request's commits.
